### PR TITLE
Use git repository link for LibYAML in docs

### DIFF
--- a/lib/psych.rb
+++ b/lib/psych.rb
@@ -33,7 +33,7 @@ require 'psych/class_loader'
 #
 # Psych is a YAML parser and emitter.
 # Psych leverages libyaml [Home page: https://pyyaml.org/wiki/LibYAML]
-# or [HG repo: https://bitbucket.org/xi/libyaml] for its YAML parsing
+# or [git repo: https://github.com/yaml/libyaml] for its YAML parsing
 # and emitting capabilities. In addition to wrapping libyaml, Psych also
 # knows how to serialize and de-serialize most Ruby objects to and from
 # the YAML format.


### PR DESCRIPTION
LibYAML has moved from their previous Mercurial based hosting on BitBucket to a git repository on GitHub. This commit updates the `Psych` module's documentation to point to this new repository, instead of the old one which is now a 404.